### PR TITLE
feat: Use dynamic port for Gradio server

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2627,8 +2627,15 @@ def main():
     print(f"Outputs: {OUTPUTS_DIR}")
     print("="*50 + "\n")
     
+    port = 7860
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port specified: {sys.argv[1]}. Using default 7860.")
+
     interface = create_interface()
-    interface.launch(server_name="127.0.0.1", server_port=7860, share=False)
+    interface.launch(server_name="127.0.0.1", server_port=port, share=False)
 
 
 if __name__ == "__main__":

--- a/start.js
+++ b/start.js
@@ -34,7 +34,7 @@ module.exports = {
         venv: "env",
         path: "app",
         message: [
-          "python app.py"
+          "python app.py {{port}}"
         ],
         on: [{
           // Match Gradio's specific "Running on local URL:" message


### PR DESCRIPTION
The application was using a hardcoded port (7860) for the Gradio server, which caused an OSError if the port was already in use.

This change modifies the application to use a dynamically assigned port, preventing port conflicts.

- app.py is updated to accept a port number as a command-line argument.

- start.js is updated to pass the dynamically assigned {{port}} variable to app.py on startup.